### PR TITLE
support python3 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
-  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
   - "3.6"
-  - "pypy"
   - "pypy3"
 install:
   - "pip install ."

--- a/lnkrypto/util.py
+++ b/lnkrypto/util.py
@@ -1,52 +1,49 @@
-import sys
+import binascii
 
-if sys.version_info[0] >= 3:
-    import binascii
+
+def int2bytes(i):
+    return i.to_bytes(max((i.bit_length() + 7) // 8, 1), byteorder='big')
+
+
+def bytes2int(b):
+    return int.from_bytes(b, byteorder='big')
+
+
+def str2bytes(s):
+    return s.encode('utf-8')
+
+
+def bytes2str(b):
+    return b.decode('utf-8')
+
+
+def hex2bytes(h):
+    return bytes.fromhex(h)
+
+
+def bytes2hex(b):
+    return bytes2str(binascii.hexlify(b))
 
 
 def int2hex(i):
-    if i < 0:
-        raise ValueError('Input integer must be not negative.')
-
-    h = hex(i)[2:].rstrip('L')
-    if len(h) % 2 == 1:
-        h = '0' + h
-    return h
+    return bytes2hex(int2bytes(i))
 
 
 def hex2int(h):
-    return int(h, 16)
+    return bytes2int(hex2bytes(h))
 
 
-if sys.version_info[0] >= 3:
-    def str2bytes(s):
-        return s.encode('utf-8')
+def hex2str(h):
+    return bytes2str(hex2bytes(h))
 
-    def bytes2str(b):
-        return b.decode('utf-8')
 
-    def hex2bytes(h):
-        return bytes.fromhex(h)
-
-    def bytes2hex(b):
-        return bytes2str(binascii.hexlify(b))
-
-    def hex2str(h):
-        return bytes2str(hex2bytes(h))
-
-    def str2hex(s):
-        return bytes2hex(str2bytes(s))
-else:
-    def hex2str(h):
-        return h.decode('hex')
-
-    def str2hex(s):
-        return s.encode('hex')
+def str2hex(s):
+    return bytes2hex(str2bytes(s))
 
 
 def int2str(i):
-    return hex2str(int2hex(i))
+    return bytes2str(int2bytes(i))
 
 
 def str2int(s):
-    return hex2int(str2hex(s))
+    return bytes2int(str2bytes(s))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,41 +1,108 @@
 from nose.tools import eq_, raises
-from lnkrypto.util import int2hex, hex2int, hex2str, str2hex, int2str, str2int
+from lnkrypto.util import \
+    int2bytes, \
+    bytes2int, \
+    str2bytes, \
+    bytes2str, \
+    hex2bytes, \
+    bytes2hex, \
+    int2hex, \
+    hex2int, \
+    hex2str, \
+    str2hex, \
+    int2str, \
+    str2int
 
 
 class TestUtil:
-    def test_int2hex_short(self):
+    def test_str2bytes(self):
+        eq_(str2bytes(''), b'')
+        eq_(str2bytes('\x12\x34'), b'\x12\x34')
+        eq_(str2bytes('sushi'), b'sushi')
+
+    def bytes2str(self):
+        eq_(bytes2str(b''), '')
+        eq_(bytes2str(b'\x12\x34'), '\x12\x34')
+        eq_(bytes2str(b'sushi'), 'sushi')
+
+    def test_hex2bytes(self):
+        eq_(hex2bytes(''), b'')
+        eq_(hex2bytes('00'), b'\x00')
+        eq_(hex2bytes('0000'), b'\x00\x00')
+        eq_(hex2bytes('0213'), b'\x02\x13')
+        eq_(hex2bytes('7375736869'), b'sushi')
+
+    @raises(ValueError)
+    def test_hex2bytes_invalid(self):
+        hex2bytes('213')
+
+    def test_bytes2hex(self):
+        eq_(bytes2hex(b''), '')
+        eq_(bytes2hex(b'\x00'), '00')
+        eq_(bytes2hex(b'\x00\x00'), '0000')
+        eq_(bytes2hex(b'\x02\x13'), '0213')
+        eq_(bytes2hex(b'sushi'), '7375736869')
+
+    def test_int2bytes(self):
+        eq_(int2bytes(0), b'\x00')
+        eq_(int2bytes(1), b'\x01')
+        eq_(int2bytes(4627), b'\x12\x13')
+        eq_(int2bytes(131260431295081), b'wasabi')
+
+    @raises(OverflowError)
+    def test_int2bytes_invalid(self):
+        int2bytes(-1)
+
+    def test_bytes2int(self):
+        eq_(bytes2int(b''), 0)
+        eq_(bytes2int(b'\x00'), 0)
+        eq_(bytes2int(b'\x00\x00'), 0)
+        eq_(bytes2int(b'\x01'), 1)
+        eq_(bytes2int(b'\x12\x13'), 4627)
+        eq_(bytes2int(b'wasabi'), 131260431295081)
+
+    def test_int2hex(self):
         eq_(int2hex(0), '00')
+        eq_(int2hex(1), '01')
         eq_(int2hex(16), '10')
         eq_(int2hex(257), '0101')
-
-    def test_int2hex_long(self):
         eq_(int2hex(12345678901234567890123456789),
             '27e41b3246bec9b16e398115')
         eq_(int2hex(123456789012345678901234567890),
             '018ee90ff6c373e0ee4e3f0ad2')
 
-    @raises(ValueError)
+    @raises(OverflowError)
     def test_int2hex_invalid(self):
         int2hex(-1)
 
     def test_hex2int(self):
+        eq_(hex2int(''), 0)
         eq_(hex2int('00'), 0)
         eq_(hex2int('1234'), 4660)
         eq_(hex2int('27e41b3246bec9b16e398115'),
             12345678901234567890123456789)
 
+    @raises(ValueError)
+    def test_hex2int_invalid(self):
+        hex2int('123')
+
     def test_hex2str(self):
         eq_(hex2str(''), '')
+        eq_(hex2str('00'), '\x00')
+        eq_(hex2str('0000'), '\x00\x00')
         eq_(hex2str('7375736869'), 'sushi')
 
     def test_str2hex(self):
         eq_(str2hex(''), '')
+        eq_(str2hex('\x00'), '00')
+        eq_(str2hex('\x00\x00'), '0000')
         eq_(str2hex('sushi'), '7375736869')
 
     def test_int2str(self):
+        eq_(int2str(0), '\x00')
         eq_(int2str(131260431295081), 'wasabi')
 
-    @raises(ValueError)
+    @raises(OverflowError)
     def test_int2str_invalid(self):
         int2str(-1)
 


### PR DESCRIPTION
This stops supporting python2.
It was too difficult to write codes which run on both python2 and python3 because strings in python2 and python3 are totally different.